### PR TITLE
Changing notation used for Big O

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ function makeTuples(input) {
                     </p>
 
                     <p>
-                        We'll get more into it later, but you can also have <code>O(log n)</code> if a code employs a divide-and-conquer strategy (often recursive,) meaning as you add more terms, the increases in time as you add input diminishes. We'll talk more about that with merge and quick sort.
+                        We'll get more into it later, but you can also have <code>O(n log n)</code> if a code employs a divide-and-conquer strategy (often recursive,) meaning as you add more terms, the increases in time as you add input diminishes. We'll talk more about that with merge and quick sort.
                     </p>
 
 


### PR DESCRIPTION
in line 111 which later refers to merge sort. As a beginner I was confused when I got to line 228 and the notation was different. I believe loglinear time O(n log n) is what is being referred to here since it mentions divide and conquer?
