### PR TITLE
Removed redundant 'to' on line 227

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@ function makeTuples(input) {
                     </p>
 
                     <p>
-                        MergeSort's Big O is <code>O(n log n)</code>. Weird, right? We obviously have to compare everything once, but we don't have to compare everything to everything like we do with bubble sort. Rather we just to have to compare to their local lists as we sort. Not too bad.
+                        MergeSort's Big O is <code>O(n log n)</code>. Weird, right? We obviously have to compare everything once, but we don't have to compare everything to everything like we do with bubble sort. Rather we just have to compare to their local lists as we sort. Not too bad.
                     </p>
 
                     <p>


### PR DESCRIPTION
Just fixing a mistake that we all often make in grammar. :)

"Rather we just to have to compare to..."
vs
"Rather we just have to compare to their local lists as we sort." 

I though about rewording it to reduce the usage of "to" one step further with:
"Rather we just have to compare against their local lists as we sort."